### PR TITLE
fix word spell: MAcGap to MacGap

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 - [Electron](https://github.com/atom/electron)
 - [Chromium Embedded Framework](https://bitbucket.org/chromiumembedded/cef)
 - [AppJS](http://appjs.com/)
-- [MAcGap](https://github.com/MacGapProject)
+- [MacGap](https://github.com/MacGapProject)
 - [TideSDK](http://www.tidesdk.org/)
 
 ## Hybrid Mobile


### PR DESCRIPTION
fix word spell: `MAcGap` to `MacGap`