### PR TITLE
Remove TideSDK link

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@
 - [Chromium Embedded Framework](https://bitbucket.org/chromiumembedded/cef)
 - [AppJS](http://appjs.com/)
 - [MacGap](https://github.com/MacGapProject)
-- [TideSDK](http://www.tidesdk.org/)
 
 ## Hybrid Mobile
 


### PR DESCRIPTION
TideSDK has been discontinued and the link is dead.  See here for details about TideSDK's discontinuation: https://stackoverflow.com/a/31369264